### PR TITLE
fixed useWindowSize() bug

### DIFF
--- a/core/database.ts
+++ b/core/database.ts
@@ -1,0 +1,31 @@
+import { HttpError } from "./httpError.ts";
+
+// Error class to throw, with a 500 status code
+export class DatabaseError extends HttpError {
+    constructor(message: string) {
+        super(`Database Error: ${message}`);
+        // set status code
+        super.status = 500;
+    }
+}
+
+// the interface to use
+export interface AttainDatabase {
+    connect(): Promise<void>;
+}
+
+// list of databases, may be useful in the future
+export enum DatabaseService {
+    MongoDB,
+    PostgreSQL,
+    MySQL,
+    Redis,
+    Cassandra,
+    MSSQL,
+    Oracle
+}
+
+export enum DatabaseType {
+    SQL,
+    NOSQL
+}

--- a/react/AttainReactUtils.js
+++ b/react/AttainReactUtils.js
@@ -109,7 +109,10 @@ export function getHead() {
 
 export function useWindowSize() {
   try {
-    if (window) {
+    // @ts-ignore
+    if (window.innerWidth) { 
+      // in the server, the window Object refers to the globalThis object 
+      // therefore won't have the properties
       const [size, setSize] = React.useState([window.innerWidth, window.innerHeight]);
       React.useLayoutEffect(() => {
         function updateSize() {


### PR DESCRIPTION
Appearently as of es11, the window object in the backend refers to the globalThis object, therefore the window object will always exist but without the right properties.